### PR TITLE
APU: Fix bug in linear counter + reduce noise vol

### DIFF
--- a/nes/apu.cpp
+++ b/nes/apu.cpp
@@ -647,10 +647,8 @@ void Apu::DoQuarterFrameStep()
 
     if (_triangleState->reloadCounter)
     {
-        bool wasZero = _triangleState->linearCounter == 0;
         _triangleState->linearCounter = _triangleState->counterReloadValue;
-        if (wasZero)
-            UpdateTriangle();
+        UpdateTriangle();
     }
     else if (_triangleState->linearCounter != 0)
     {

--- a/nes/audio.cpp
+++ b/nes/audio.cpp
@@ -399,7 +399,7 @@ void AudioEngine::GenerateSamples(u8* stream, int count)
 
         double output = 2.95e-5 * pulseSample +
             3.34e-5 * triangleSample +
-            0.00494 * noiseSample +
+            0.00247 * noiseSample +
             0.00335 * _dmcAmplitude;
 
         *stream++ = (u8)(output * _silenceValue + _silenceValue);


### PR DESCRIPTION
Fixed bug in the linear counter (sometimes the triangle channel would incorrectly keep playing).
Reduced the volume of the noise channel.