### PR TITLE
Fix pulse sweep bugs

### DIFF
--- a/nes/apu.cpp
+++ b/nes/apu.cpp
@@ -424,7 +424,7 @@ void Apu::WriteApuPulse1(u8 val, ApuPulseState* state)
 {
     state->sweepEnabled = (val & 0x80) != 0;
     state->negate = (val & 0x08) != 0;
-    state->sweepPeriod = (val >> 4) & 0x07;
+    state->sweepPeriod = ((val >> 4) & 0x07) + 1;
     state->shiftAmount = val & 0x07;
     state->sweepReset = true;
 }
@@ -765,7 +765,7 @@ void Apu::StepSweep(ApuPulseState* state)
     {
         if (state->sweepReset)
         {
-            state->sweepCounter = 0;
+            state->sweepCounter = state->sweepPeriod;
             state->sweepReset = false;
         }
         else if (state->sweepCounter != 0)

--- a/nes/audio.cpp
+++ b/nes/audio.cpp
@@ -399,7 +399,8 @@ void AudioEngine::GenerateSamples(u8* stream, int count)
         triangleSample = SampleWavetableChannel(_triangleChannel);
         noiseSample = SampleNoise();
 
-        double output = 2.95e-5 * pulseSample +
+        double output =
+            2.95e-5 * pulseSample +
             3.34e-5 * triangleSample +
             0.00247 * noiseSample +
             0.00335 * _dmcAmplitude;
@@ -511,9 +512,9 @@ void AudioEngine::ProcessAudioEvent(const AudioEvent& event)
             _pulseChannel1.wavetable,
             _pulseChannel1.frequency,
             _pulseChannel1.volume,
-            _pulseChannel1.wavetable,
-            _pulseChannel1.frequency,
-            _pulseChannel1.volume,
+            _pulseChannel2.wavetable,
+            _pulseChannel2.frequency,
+            _pulseChannel2.volume,
             _triangleChannel.frequency,
             _noiseMode1 ? 1 : 0,
             (int)_noisePeriodSamples,


### PR DESCRIPTION
Fix two bugs in the pulse sweep code:
1.  Pulse counter was being loaded with wrong value
2.  Very hard to track down audio glitch was actually an off-by-one error