### PR TITLE
APU: Improve audio hack

### DIFF
--- a/nes/audio.cpp
+++ b/nes/audio.cpp
@@ -555,8 +555,18 @@ void AudioEngine::UpdateTriangleFrequency(u32 newFreq)
         else
             diff = newFreq - oldFreq;
 
-        _triangleChannel.rampUp = false;
-        _triangleChannel.rampDown = true;
+        if (diff > WAVETABLE_SAMPLES)
+        {
+            // Lange frequency change - do the ramp down/up
+            _triangleChannel.rampUp = false;
+            _triangleChannel.rampDown = true;
+        }
+        else if (!_triangleChannel.rampDown)
+        {
+            // Small change and we are not already ramping down - set new frequency now
+            _triangleChannel.frequency = newFreq;
+            UpdateWavetableRow(_triangleChannel);
+        }
     }
 }
 


### PR DESCRIPTION
There's currently a hack in the audio engine to reduce popping sounds when the triangle channel frequency changes too quickly by ramping the volume down during the frequency change.  The hack was causing a problem with games that change the triangle frequency rapidly.  "Improved" the hack by not doing the volume ramp when the frequency change is below a certain threshold.  This improves things, but weird volume artifacts are still present when changing higher frequency notes.  Doing a better job would require a non-linear threshold, but I don't think it's worth investing too much effort into the hack.

Ultimately we need to add a band pass DSP filter, but that will be a significant amount of work.

