### PR TITLE
Remove windows specific code

### DIFF
--- a/nes/audio.h
+++ b/nes/audio.h
@@ -134,7 +134,7 @@ private:
 
     // Audio engine state information
     EventQueue<AudioEvent> _eventQueue;
-    volatile u32 _pendingFrameResetCount;
+    std::atomic<u32> _pendingFrameResetCount;
     AudioEvent _nextEvent;
     int _samplesRemaining;
     bool _eventPending;

--- a/nes/mem.cpp
+++ b/nes/mem.cpp
@@ -16,7 +16,7 @@ MemoryMap::MemoryMap(std::shared_ptr<Ppu> ppu, std::shared_ptr<Apu> apu, std::sh
     , _input(input)
     , _mapper(mapper)
 {
-    ZeroMemory(_ram, sizeof(_ram));
+    memset(_ram, 0, sizeof(_ram));
 }
 
 MemoryMap::~MemoryMap()

--- a/nes/nes.cpp
+++ b/nes/nes.cpp
@@ -87,7 +87,7 @@ void Nes::Run(IGfx* gfx, IInput* input)
     u8 screen[256 * 240 * 3];
     for (;;)
     {
-        ZeroMemory(screen, sizeof(screen));
+        memset(screen, 0, sizeof(screen));
 
         // TODO: get joypadState
         InputResult result = input->CheckInput(_input->State);

--- a/nes/new_ppu.cpp
+++ b/nes/new_ppu.cpp
@@ -771,8 +771,8 @@ bool Ppu::GetSpriteColor(u8 x, u8 y, bool backgroundOpaque, u8& paletteIndex, Sp
 VRam::VRam(std::shared_ptr<IMapper> mapper)
     : _mapper(mapper)
 {
-    ZeroMemory(_nametables, sizeof(_nametables));
-    ZeroMemory(_palette, sizeof(_palette));
+    memset(_nametables, 0, sizeof(_nametables));
+    memset(_palette, 0, sizeof(_palette));
 }
 
 VRam::~VRam()
@@ -883,7 +883,7 @@ void VRam::LoadState(std::ifstream& ifs)
 
 Oam::Oam()
 {
-    ZeroMemory(_ram, sizeof(_ram));
+    memset(_ram, 0, sizeof(_ram));
 }
 
 Oam::~Oam()

--- a/nes/rom.h
+++ b/nes/rom.h
@@ -44,7 +44,7 @@ struct INesHeader
             PrgRamSize = 0;
             flags9 = 0;
             flags10 = 0;
-            ZeroMemory(zero, sizeof(zero));
+            memset(zero, 0, sizeof(zero));
         }
 
         return true;

--- a/nes/stdafx.h
+++ b/nes/stdafx.h
@@ -5,12 +5,7 @@
 
 #pragma once
 
-#include <math.h>
-#include <stdio.h>
-#include <tchar.h>
-
-#include <atlbase.h>
-
+// std C++ includes
 #include <iostream>
 #include <fstream>
 #include <string>
@@ -19,6 +14,7 @@
 #include <memory>
 #include <vector>
 #include <chrono>
+#include <atomic>
 
 // for Rom and save state paths
 #include <experimental/filesystem>


### PR DESCRIPTION
Remove uses of the ZeroMemory macro and windows atomic primitives. Adds std::atomic instead.