### PR TITLE
Initialize sprite data to empty/zero

### DIFF
--- a/nes/new_ppu.cpp
+++ b/nes/new_ppu.cpp
@@ -23,6 +23,9 @@ Ppu::Ppu(std::shared_ptr<IMapper> mapper)
     , _clipSprites(false)
     , _showBackground(false)
     , _showSprites(false)
+    , _oamAddr(0)
+    , _lineSprites(0)
+    , _spriteZeroOnLine(false)
 {
 }
 


### PR DESCRIPTION
Information related to sprite rendering was not getting initalized to zero
in the ppu. This could cause initial sprites in a game to be bogus.