### PR TITLE
Improve handling of simultaneous left/right up/down

### DIFF
--- a/nes/input.cpp
+++ b/nes/input.cpp
@@ -76,6 +76,10 @@ StandardController::StandardController()
     , _Down(false)
     , _Left(false)
     , _Right(false)
+    , _Up_actual(false)
+    , _Down_actual(false)
+    , _Left_actual(false)
+    , _Right_actual(false)
     , _strobe(false)
     , _nextReadIndex(0)
 {
@@ -146,36 +150,61 @@ void StandardController::Start(bool state)
 
 void StandardController::Up(bool state)
 {
-    if (state)
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_Down_actual)
     {
-        _Down = false;
+        _Up = false;
+        _Down = !state;
     }
-    _Up = state;
+    else
+    {
+        _Up = state;
+    }
+
+    _Up_actual = state;
 }
 
 void StandardController::Down(bool state)
 {
-    if (state)
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_Up_actual)
     {
-        _Up = false;
+        _Down = false;
+        _Up = !state;
     }
-    _Down = state;
+    else
+    {
+        _Down = state;
+    }
+    _Down_actual = state;
 }
 
 void StandardController::Left(bool state)
 {
-    if (state)
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_Right_actual)
     {
-        _Right = false;
+        _Left = false;
+        _Right = !state;
     }
-    _Left = state;
+    else
+    {
+        _Left = state;
+    }
+    _Left_actual = state;
 }
 
 void StandardController::Right(bool state)
 {
-    if (state)
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_Left_actual)
     {
-        _Left = false;
+        _Right = false;
+        _Left = !state;
     }
-    _Right = state;
+    else
+    {
+        _Right = state;
+    }
+    _Right_actual = state;
 }

--- a/nes/input.h
+++ b/nes/input.h
@@ -62,14 +62,33 @@ public:
     void Right(bool state);
 
 private:
+    std::mutex _mutex;
+
     std::atomic<bool> _A;
     std::atomic<bool> _B;
     std::atomic<bool> _Select;
     std::atomic<bool> _Start;
+
+    // for up/down/left/right, we don't allow left/right or up/down to be pressed at the same time
+    // if both up/down or left/right are pressed, we treat it like neither are
+    // to accomplish this we have to track two things: the current state the buttons are actually in
+    // and the state that we will send to the nes
+    // This is important to make the following scenario work:
+    // User is holding left: left is the input
+    // User holds down right in addition to holding down left: input is neither right nor left is pressed
+    // User releases right, still holding down left: left is the input
+
+    // NES visible
     std::atomic<bool> _Up;
     std::atomic<bool> _Down;
     std::atomic<bool> _Left;
     std::atomic<bool> _Right;
+
+    // Actual states
+    std::atomic<bool> _Up_actual;
+    std::atomic<bool> _Down_actual;
+    std::atomic<bool> _Left_actual;
+    std::atomic<bool> _Right_actual;
 
     std::atomic<bool> _strobe;
     u8 _nextReadIndex;

--- a/nes/stdafx.h
+++ b/nes/stdafx.h
@@ -15,6 +15,7 @@
 #include <vector>
 #include <chrono>
 #include <atomic>
+#include <mutex>
 
 // for Rom and save state paths
 #include <experimental/filesystem>


### PR DESCRIPTION
This improves our behavior for handling simultaneous up/down, left/right
presses. If at any point we detect that both up and down or both left and
right are pressed, we treat it as if neither of them are. We also
correctly handle when buttons are released from a both pressed state. This
also introduces a mutex and lock_guard pattern to keep the button presses
thread safe.