### PR TITLE
Remove SDL specifics from APU implementation

### DIFF
--- a/include/nes_api.h
+++ b/include/nes_api.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #if defined(_WIN32)
   #if defined(NES_EXPORTS)
     #define NES_API __declspec(dllexport)
@@ -22,6 +24,21 @@ struct INes
     virtual void LoadState() = 0;
 };
 
+// Audio interface (implemented by host)
+typedef void AudioCallback(void *userdata, unsigned char *stream, int len);
+struct IAudioProvider
+{
+    // Called by nes with its callback when it's ready to begin audio rendering
+    virtual void Initialize(AudioCallback* callback, void* callbackData) = 0;
+
+    // The following calls will only be made after Initialize is called
+    virtual void PauseAudio() = 0;
+    virtual void UnpauseAudio() = 0;
+    virtual int GetSampleRate() = 0;
+    virtual int GetBitsPerSample() = 0;
+    virtual int GetSilenceValue() = 0;
+};
+
 // Standard Controller Interface
 struct IStandardController
 {
@@ -37,5 +54,5 @@ struct IStandardController
 
 extern "C"
 {
-    NES_API INes* Nes_Create(const char* romPath);
+    NES_API INes* Nes_Create(const char* romPath, std::shared_ptr<IAudioProvider> audioProvider);
 }

--- a/neSDL/neSDL.cpp
+++ b/neSDL/neSDL.cpp
@@ -8,6 +8,7 @@
 
 #include <nes_api.h>
 
+#include "sdlAudio.h"
 #include "sdlGfx.h"
 #include "sdlInput.h"
 
@@ -19,7 +20,8 @@ int main(int argc, char* argv[])
         return -1;
     }
 
-    INes* nes = Nes_Create(argv[1]);
+    std::shared_ptr<SdlAudioProvider> audioProvider = std::make_shared<SdlAudioProvider>(44100);
+    INes* nes = Nes_Create(argv[1], audioProvider);
     if (nes == nullptr)
     {
         return 1;

--- a/neSDL/sdlAudio.cpp
+++ b/neSDL/sdlAudio.cpp
@@ -1,0 +1,88 @@
+
+#include "sdlAudio.h"
+
+#include <stdio.h>
+#include <SDL.h>
+
+#define SAMPLE_BUFFER_SIZE 1024
+
+SdlAudioProvider::SdlAudioProvider(int sampleRate)
+    : _deviceId(0)
+    , _format(AUDIO_U8)
+    , _sampleRate(sampleRate)
+    , _bufferSize(SAMPLE_BUFFER_SIZE)
+    , _silenceValue(0)
+{
+}
+
+SdlAudioProvider::~SdlAudioProvider()
+{
+    if (_deviceId != 0)
+    {
+        SDL_CloseAudioDevice(_deviceId);
+
+        _deviceId = 0;
+    }
+
+    SDL_QuitSubSystem(SDL_INIT_AUDIO);
+}
+
+void SdlAudioProvider::Initialize(AudioCallback* callback, void* callbackData)
+{
+    SDL_InitSubSystem(SDL_INIT_AUDIO);
+
+    SDL_AudioSpec desired = { 0 };
+    SDL_AudioSpec obtained = { 0 };
+    desired.format = _format;
+    desired.channels = 1;
+    desired.freq = _sampleRate;
+    desired.samples = _bufferSize;
+    desired.callback = callback;
+    desired.userdata = callbackData;
+
+    _deviceId = SDL_OpenAudioDevice(
+        nullptr /* Choose reasonable default device */,
+        false /* Capture disabled */,
+        &desired,
+        &obtained,
+        SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
+    if (_deviceId == 0)
+    {
+        AudioError(SDL_GetError());
+        return;
+    }
+
+    _sampleRate = obtained.freq;
+    _silenceValue = obtained.silence;
+}
+
+void SdlAudioProvider::PauseAudio()
+{
+    SDL_PauseAudioDevice(_deviceId, 1);
+}
+
+void SdlAudioProvider::UnpauseAudio()
+{
+    SDL_PauseAudioDevice(_deviceId, 0);
+}
+
+int SdlAudioProvider::GetSampleRate()
+{
+    return _sampleRate;
+}
+
+int SdlAudioProvider::GetBitsPerSample()
+{
+    return 8; // TODO: Multi-bitrate support
+}
+
+int SdlAudioProvider::GetSilenceValue()
+{
+    return _silenceValue;
+}
+
+void SdlAudioProvider::AudioError(const char* error)
+{
+    // TODO: Do something different in the emulator?
+    printf_s("Audio Engine Error: %s", error);
+}

--- a/neSDL/sdlAudio.h
+++ b/neSDL/sdlAudio.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <nes_api.h>
+#include <SDL_audio.h>
+
+class SdlAudioProvider : public IAudioProvider
+{
+public:
+    SdlAudioProvider(int sampleRate);
+    virtual ~SdlAudioProvider();
+
+    // IAudioProvider implementation
+    virtual void Initialize(AudioCallback* callback, void* callbackData);
+    virtual void PauseAudio();
+    virtual void UnpauseAudio();
+    virtual int GetSampleRate();
+    virtual int GetBitsPerSample();
+    virtual int GetSilenceValue();
+
+private:
+    void AudioError(const char* error);
+
+private:
+    SDL_AudioDeviceID _deviceId;
+    SDL_AudioFormat _format;
+    int _sampleRate;
+    int _bufferSize;
+    int _silenceValue;
+};

--- a/neSDL/win32/neSDL.vcxproj
+++ b/neSDL/win32/neSDL.vcxproj
@@ -84,10 +84,12 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\neSDL.cpp" />
+    <ClCompile Include="..\sdlAudio.cpp" />
     <ClCompile Include="..\sdlGfx.cpp" />
     <ClCompile Include="..\sdlInput.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\sdlAudio.h" />
     <ClInclude Include="..\sdlGfx.h" />
     <ClInclude Include="..\sdlInput.h" />
   </ItemGroup>

--- a/neSDL/win32/neSDL.vcxproj.filters
+++ b/neSDL/win32/neSDL.vcxproj.filters
@@ -20,12 +20,18 @@
     <ClCompile Include="..\neSdl.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\sdlAudio.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\sdlGfx.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\sdlInput.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\sdlAudio.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/apu.cpp
+++ b/src/apu.cpp
@@ -247,7 +247,7 @@ struct ApuEnvelop
 
 // APU implementation
 
-Apu::Apu(bool isPal)
+Apu::Apu(bool isPal, std::shared_ptr<IAudioProvider> audioProvider)
     : _frameInterrupt(false)
     , _frameInterruptInhibit(false)
     , _frameCounterMode1(false)
@@ -275,7 +275,7 @@ Apu::Apu(bool isPal)
     memset(_pulseEnvelop2, 0, sizeof(ApuEnvelop));
     memset(_noiseEnvelop, 0, sizeof(ApuEnvelop));
 
-    _audioEngine = new AudioEngine();
+    _audioEngine = new AudioEngine(audioProvider);
     _pulseState1->frequencySetting = NESAUDIO_PULSE1_FREQUENCY;
     _pulseState2->frequencySetting = NESAUDIO_PULSE2_FREQUENCY;
     _pulseState1->dutyCycleSetting = NESAUDIO_PULSE1_DUTYCYCLE;

--- a/src/apu.h
+++ b/src/apu.h
@@ -3,6 +3,7 @@
 #include "mem.h"
 
 class AudioEngine;
+struct IAudioProvider;
 struct ApuPulseState;
 struct ApuTriangleState;
 struct ApuNoiseState;
@@ -22,7 +23,7 @@ struct ApuStepResult
 class Apu : public IMem
 {
 public:
-    Apu(bool isPal);
+    Apu(bool isPal, std::shared_ptr<IAudioProvider> audioProvider);
     ~Apu();
 
     // Audio control

--- a/src/audio.h
+++ b/src/audio.h
@@ -2,6 +2,8 @@
 
 #include "eventqueue.h"
 
+struct IAudioProvider;
+
 enum WavetableIndex
 {
     NESAUDIO_PULSE_DUTYCYCLE_12_5 = 0, // Pulse channel 12.5% duty cycle
@@ -66,7 +68,7 @@ struct WavetableChannel
 class AudioEngine
 {
 public:
-    AudioEngine();
+    AudioEngine(std::shared_ptr<IAudioProvider> audioProvider);
     virtual ~AudioEngine();
 
     void StartAudio(
@@ -90,8 +92,6 @@ private:
     void GenerateTable(int minFreq, int maxFreq, double (fourierSeriesFunction)(int phase, int harmonic), u8* wavetable);
     void GenarateOtherPulseTables();
 
-    void AudioError(const char* error);
-
     void ExecuteCallback(u8* stream, int len);
     void GenerateSamples(u8* stream, int count);
     void ProcessAudioEvents();
@@ -107,7 +107,8 @@ private:
 
 private:
     // Audio device info
-    SDL_AudioDeviceID _deviceId;
+    std::shared_ptr<IAudioProvider> _audioProvider;
+    bool _audioStarted;
     int _sampleRate;
     u8 _silenceValue;
 

--- a/src/nes.cpp
+++ b/src/nes.cpp
@@ -11,12 +11,12 @@
 #include "apu.h"
 #include "mapper.h"
 
-Nes::Nes(std::shared_ptr<Rom> rom, std::shared_ptr<IMapper> mapper)
+Nes::Nes(std::shared_ptr<Rom> rom, std::shared_ptr<IMapper> mapper, std::shared_ptr<IAudioProvider> audioProvider)
     : _rom(rom)
     , _mapper(mapper)
 {
     _ppu = std::make_shared<Ppu>(_mapper);
-    _apu = std::make_shared<Apu>(false);
+    _apu = std::make_shared<Apu>(false, audioProvider);
     _input = std::make_shared<Input>();
     _mem = std::make_shared<MemoryMap>(_ppu, _apu, _input, _mapper);
     _cpu = std::make_unique<Cpu>(_mem);
@@ -31,16 +31,16 @@ Nes::~Nes()
     _apu->StopAudio();
 }
 
-std::unique_ptr<Nes> Nes::Create(const char* romPath)
+std::unique_ptr<Nes> Nes::Create(const char* romPath, std::shared_ptr<IAudioProvider> audioProvider)
 {
     auto rom = std::make_shared<Rom>();
     if (!rom->Load(romPath))
         return nullptr;
 
-    return Nes::Create(rom);
+    return Nes::Create(rom, audioProvider);
 }
 
-std::unique_ptr<Nes> Nes::Create(std::shared_ptr<Rom> rom)
+std::unique_ptr<Nes> Nes::Create(std::shared_ptr<Rom> rom, std::shared_ptr<IAudioProvider> audioProvider)
 {
     auto mapper = IMapper::CreateMapper(rom);
     if (mapper == nullptr)
@@ -48,7 +48,7 @@ std::unique_ptr<Nes> Nes::Create(std::shared_ptr<Rom> rom)
         return nullptr;
     }
 
-    return std::make_unique<Nes>(rom, mapper);
+    return std::make_unique<Nes>(rom, mapper, audioProvider);
 }
 
 void Nes::DoFrame(u8 screen[])

--- a/src/nes.h
+++ b/src/nes.h
@@ -12,11 +12,11 @@ class Input;
 class Nes : public INes
 {
 public:
-    Nes(std::shared_ptr<Rom> rom, std::shared_ptr<IMapper> mapper);
+    Nes(std::shared_ptr<Rom> rom, std::shared_ptr<IMapper> mapper, std::shared_ptr<IAudioProvider> audioProvider);
     ~Nes();
 
-    static std::unique_ptr<Nes> Create(const char* romPath);
-    static std::unique_ptr<Nes> Create(std::shared_ptr<Rom> rom);
+    static std::unique_ptr<Nes> Create(const char* romPath, std::shared_ptr<IAudioProvider> audioProvider);
+    static std::unique_ptr<Nes> Create(std::shared_ptr<Rom> rom, std::shared_ptr<IAudioProvider> audioProvider);
 
     // DoFrame runs all nes components until the ppu hits VBlank
     // This means that one call to DoFrame will render scanlines 241 - 261 then 0 - 240

--- a/src/nes_api.cpp
+++ b/src/nes_api.cpp
@@ -4,7 +4,7 @@
 
 std::unique_ptr<Nes> _g_Nes = nullptr;
 
-INes* Nes_Create(const char* romPath)
+INes* Nes_Create(const char* romPath, std::shared_ptr<IAudioProvider> audioProvider)
 {
     // HACK
     // TOOD: fix.
@@ -14,7 +14,7 @@ INes* Nes_Create(const char* romPath)
     }
     else
     {
-        _g_Nes = Nes::Create(romPath);
+        _g_Nes = Nes::Create(romPath, audioProvider);
         return _g_Nes.get();
     }
 }

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -5,6 +5,10 @@
 
 #pragma once
 
+// C includes
+#define _USE_MATH_DEFINES
+#include <math.h>
+
 // std C++ includes
 #include <iostream>
 #include <fstream>
@@ -28,7 +32,3 @@ namespace fs = std::experimental::filesystem;
 // Emulator constants
 #define CPU_FREQ_NTSC 1789773
 #define CPU_FREQ_PAL 1662607
-
-// Still required for APU
-#define SDL_MAIN_HANDLED
-#include <SDL.h>

--- a/src/win32/nes.vcxproj
+++ b/src/win32/nes.vcxproj
@@ -111,6 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;WIN32_EXPORTS;NES_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -125,6 +126,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;WIN32_EXPORTS;NES_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -141,6 +143,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;WIN32_EXPORTS;NES_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
This is the last change required to remove nes.dll's dependency on SDL.