### PR TITLE
Remove std::shared_ptr from nes_api and update neSDL

### DIFF
--- a/include/nes_api.h
+++ b/include/nes_api.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <memory>
-
 #if defined(_WIN32)
   #if defined(NES_EXPORTS)
     #define NES_API __declspec(dllexport)
@@ -54,5 +52,6 @@ struct IStandardController
 
 extern "C"
 {
-    NES_API INes* Nes_Create(const char* romPath, std::shared_ptr<IAudioProvider> audioProvider);
+    NES_API INes* Nes_Create(const char* romPath, IAudioProvider* audioProvider);
+    NES_API void Nes_Destroy(INes* nes);
 }

--- a/neSDL/neSDL.cpp
+++ b/neSDL/neSDL.cpp
@@ -20,8 +20,8 @@ int main(int argc, char* argv[])
         return -1;
     }
 
-    std::shared_ptr<SdlAudioProvider> audioProvider = std::make_shared<SdlAudioProvider>(44100);
-    INes* nes = Nes_Create(argv[1], audioProvider);
+    SdlAudioProvider audioProvider(44100);
+    INes* nes = Nes_Create(argv[1], static_cast<IAudioProvider*>(&audioProvider));
     if (nes == nullptr)
     {
         return 1;
@@ -37,7 +37,6 @@ int main(int argc, char* argv[])
     {
         memset(screen, 0, sizeof(screen));
 
-        // TODO: get joypadState
         InputResult result = input.CheckInput();
 
         if (result == InputResult::SaveState)
@@ -56,4 +55,5 @@ int main(int argc, char* argv[])
         nes->DoFrame(screen);
         gfx.Blit(screen);
     }
+    Nes_Destroy(nes);
 }

--- a/neSDL/neSDL.cpp
+++ b/neSDL/neSDL.cpp
@@ -1,13 +1,4 @@
-//#include "nes.h"
-//#include "IInput.h"
-//#include "sdlGfx.h"
-//#include "sdlInput.h"
-
-#include <stdio.h>
-#include <memory>
-
-#include <nes_api.h>
-
+#include "stdafx.h"
 #include "sdlAudio.h"
 #include "sdlGfx.h"
 #include "sdlInput.h"

--- a/neSDL/sdlAudio.cpp
+++ b/neSDL/sdlAudio.cpp
@@ -1,7 +1,6 @@
-
+#include "stdafx.h"
 #include "sdlAudio.h"
 
-#include <stdio.h>
 #include <SDL.h>
 
 #define SAMPLE_BUFFER_SIZE 1024

--- a/neSDL/sdlAudio.h
+++ b/neSDL/sdlAudio.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <nes_api.h>
 #include <SDL_audio.h>
 
 class SdlAudioProvider : public IAudioProvider

--- a/neSDL/sdlGfx.cpp
+++ b/neSDL/sdlGfx.cpp
@@ -1,5 +1,5 @@
+#include "stdafx.h"
 #include "sdlGfx.h"
-#include <SDL.h>
 
 #if !defined(RENDER_GRID)
 const unsigned int SCREEN_WIDTH = 256;

--- a/neSDL/sdlInput.cpp
+++ b/neSDL/sdlInput.cpp
@@ -1,6 +1,5 @@
+#include "stdafx.h"
 #include "sdlInput.h"
-#include <SDL.h>
-#include <nes_api.h>
 
 SdlInput::SdlInput(IStandardController* controller0)
 {

--- a/neSDL/stdafx.cpp
+++ b/neSDL/stdafx.cpp
@@ -1,0 +1,1 @@
+#include "stdafx.h"

--- a/neSDL/stdafx.h
+++ b/neSDL/stdafx.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <stdio.h>
+#include <nes_api.h>
+
+#define SDL_MAIN_HANDLED
+#include <SDL.h>

--- a/neSDL/win32/neSDL.vcxproj
+++ b/neSDL/win32/neSDL.vcxproj
@@ -87,11 +87,15 @@
     <ClCompile Include="..\sdlAudio.cpp" />
     <ClCompile Include="..\sdlGfx.cpp" />
     <ClCompile Include="..\sdlInput.cpp" />
+    <ClCompile Include="..\stdafx.cpp">
+	  <PrecompiledHeader>Create</PrecompiledHeader>
+	</ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\sdlAudio.h" />
     <ClInclude Include="..\sdlGfx.h" />
     <ClInclude Include="..\sdlInput.h" />
+    <ClInclude Include="..\stdafx.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\win32\nes.vcxproj">

--- a/neSDL/win32/neSDL.vcxproj.filters
+++ b/neSDL/win32/neSDL.vcxproj.filters
@@ -23,6 +23,9 @@
     <ClCompile Include="..\sdlAudio.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\stdafx.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\sdlGfx.h">
@@ -32,6 +35,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\sdlAudio.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\stdafx.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/apu.cpp
+++ b/src/apu.cpp
@@ -247,7 +247,7 @@ struct ApuEnvelop
 
 // APU implementation
 
-Apu::Apu(bool isPal, std::shared_ptr<IAudioProvider> audioProvider)
+Apu::Apu(bool isPal, IAudioProvider* audioProvider)
     : _frameInterrupt(false)
     , _frameInterruptInhibit(false)
     , _frameCounterMode1(false)

--- a/src/apu.h
+++ b/src/apu.h
@@ -23,7 +23,7 @@ struct ApuStepResult
 class Apu : public IMem
 {
 public:
-    Apu(bool isPal, std::shared_ptr<IAudioProvider> audioProvider);
+    Apu(bool isPal, IAudioProvider* audioProvider);
     ~Apu();
 
     // Audio control

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -1,7 +1,6 @@
 #include "stdafx.h"
+#include "..\include\nes_api.h"
 #include "audio.h"
-
-#include <nes_api.h>
 
 //#define SOUND_EVENT_TRACE
 
@@ -31,7 +30,7 @@ static double TriangleFourierFunction(int phase, int harmonic)
     return pow(-1.0, (harmonic - 1) / 2) * (1.0 / (harmonic * harmonic)) * sin(harmonic * M_PI * 2.0 * ((double)phase / WAVETABLE_SAMPLES));
 }
 
-AudioEngine::AudioEngine(std::shared_ptr<IAudioProvider> audioProvider)
+AudioEngine::AudioEngine(IAudioProvider* audioProvider)
     : _audioProvider(audioProvider)
     , _audioStarted(false)
     , _sampleRate(0)

--- a/src/audio.h
+++ b/src/audio.h
@@ -68,7 +68,7 @@ struct WavetableChannel
 class AudioEngine
 {
 public:
-    AudioEngine(std::shared_ptr<IAudioProvider> audioProvider);
+    AudioEngine(IAudioProvider* audioProvider);
     virtual ~AudioEngine();
 
     void StartAudio(
@@ -107,7 +107,7 @@ private:
 
 private:
     // Audio device info
-    std::shared_ptr<IAudioProvider> _audioProvider;
+    IAudioProvider* _audioProvider;
     bool _audioStarted;
     int _sampleRate;
     u8 _silenceValue;

--- a/src/nes.cpp
+++ b/src/nes.cpp
@@ -11,7 +11,7 @@
 #include "apu.h"
 #include "mapper.h"
 
-Nes::Nes(std::shared_ptr<Rom> rom, std::shared_ptr<IMapper> mapper, std::shared_ptr<IAudioProvider> audioProvider)
+Nes::Nes(std::shared_ptr<Rom> rom, std::shared_ptr<IMapper> mapper, IAudioProvider* audioProvider)
     : _rom(rom)
     , _mapper(mapper)
 {
@@ -31,7 +31,7 @@ Nes::~Nes()
     _apu->StopAudio();
 }
 
-std::unique_ptr<Nes> Nes::Create(const char* romPath, std::shared_ptr<IAudioProvider> audioProvider)
+std::unique_ptr<Nes> Nes::Create(const char* romPath, IAudioProvider* audioProvider)
 {
     auto rom = std::make_shared<Rom>();
     if (!rom->Load(romPath))
@@ -40,7 +40,7 @@ std::unique_ptr<Nes> Nes::Create(const char* romPath, std::shared_ptr<IAudioProv
     return Nes::Create(rom, audioProvider);
 }
 
-std::unique_ptr<Nes> Nes::Create(std::shared_ptr<Rom> rom, std::shared_ptr<IAudioProvider> audioProvider)
+std::unique_ptr<Nes> Nes::Create(std::shared_ptr<Rom> rom, IAudioProvider* audioProvider)
 {
     auto mapper = IMapper::CreateMapper(rom);
     if (mapper == nullptr)

--- a/src/nes.h
+++ b/src/nes.h
@@ -12,11 +12,11 @@ class Input;
 class Nes : public INes
 {
 public:
-    Nes(std::shared_ptr<Rom> rom, std::shared_ptr<IMapper> mapper, std::shared_ptr<IAudioProvider> audioProvider);
+    Nes(std::shared_ptr<Rom> rom, std::shared_ptr<IMapper> mapper, IAudioProvider* audioProvider);
     ~Nes();
 
-    static std::unique_ptr<Nes> Create(const char* romPath, std::shared_ptr<IAudioProvider> audioProvider);
-    static std::unique_ptr<Nes> Create(std::shared_ptr<Rom> rom, std::shared_ptr<IAudioProvider> audioProvider);
+    static std::unique_ptr<Nes> Create(const char* romPath, IAudioProvider* audioProvider);
+    static std::unique_ptr<Nes> Create(std::shared_ptr<Rom> rom, IAudioProvider* audioProvider);
 
     // DoFrame runs all nes components until the ppu hits VBlank
     // This means that one call to DoFrame will render scanlines 241 - 261 then 0 - 240

--- a/src/nes_api.cpp
+++ b/src/nes_api.cpp
@@ -4,7 +4,7 @@
 
 std::unique_ptr<Nes> _g_Nes = nullptr;
 
-INes* Nes_Create(const char* romPath, std::shared_ptr<IAudioProvider> audioProvider)
+INes* Nes_Create(const char* romPath, IAudioProvider* audioProvider)
 {
     // HACK
     // TOOD: fix.
@@ -17,4 +17,9 @@ INes* Nes_Create(const char* romPath, std::shared_ptr<IAudioProvider> audioProvi
         _g_Nes = Nes::Create(romPath, audioProvider);
         return _g_Nes.get();
     }
+}
+
+void Nes_Destroy(INes* nes)
+{
+    _g_Nes.release();
 }

--- a/src/win32/nes.vcxproj
+++ b/src/win32/nes.vcxproj
@@ -50,9 +50,6 @@
     </ClCompile>
     <ClCompile Include="..\util.cpp" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{6DAAE93F-341D-420B-92B0-34E769A28F93}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -111,7 +108,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;WIN32_EXPORTS;NES_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -126,7 +123,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;WIN32_EXPORTS;NES_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -143,7 +140,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;WIN32_EXPORTS;NES_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -153,15 +150,5 @@
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\sdl2.v140.redist.2.0.4\build\native\sdl2.v140.redist.targets" Condition="Exists('..\..\packages\sdl2.v140.redist.2.0.4\build\native\sdl2.v140.redist.targets')" />
-    <Import Project="..\..\packages\sdl2.v140.2.0.4\build\native\sdl2.v140.targets" Condition="Exists('..\..\packages\sdl2.v140.2.0.4\build\native\sdl2.v140.targets')" />
-  </ImportGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\sdl2.v140.redist.2.0.4\build\native\sdl2.v140.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\sdl2.v140.redist.2.0.4\build\native\sdl2.v140.redist.targets'))" />
-    <Error Condition="!Exists('..\..\packages\sdl2.v140.2.0.4\build\native\sdl2.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\sdl2.v140.2.0.4\build\native\sdl2.v140.targets'))" />
-  </Target>
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/src/win32/nes.vcxproj.filters
+++ b/src/win32/nes.vcxproj.filters
@@ -9,10 +9,6 @@
       <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
       <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
     </Filter>
-    <Filter Include="Resource Files">
-      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
-      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
-    </Filter>
     <Filter Include="API Headers">
       <UniqueIdentifier>{cf1c6db8-790a-4547-ad33-f807cd5d834b}</UniqueIdentifier>
     </Filter>
@@ -110,8 +106,5 @@
     <ClCompile Include="..\ppu.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/src/win32/packages.config
+++ b/src/win32/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="sdl2.v140" version="2.0.4" targetFramework="native" />
-  <package id="sdl2.v140.redist" version="2.0.4" targetFramework="native" />
-</packages>


### PR DESCRIPTION
I don't love the bare pointer either, and I am open to suggestions. I just don't want to introduce std types into the API.