### PR TITLE
Create RomBase class to isolate host file IO operations

### DIFF
--- a/include/nes_api.h
+++ b/include/nes_api.h
@@ -18,6 +18,36 @@
 struct INes;
 struct IStandardController;
 
+struct IReadStream;
+struct IWriteStream;
+struct IRomFile;
+
+struct IReadStream : public IBaseInterface
+{
+    // Read bytes from the stream
+    // buf: the buffer that bytes will be read into
+    // count: the maximum number of bytes to read
+    // returns: the total number of bytes read
+    virtual int ReadBytes(unsigned char* buf, int count) = 0;
+};
+
+struct IWriteStream : public IBaseInterface
+{
+
+    // Write bytes to the stream
+    // buf: the buffer containing bytse to be written
+    // count: the maximum number of bytes to write
+    // returns: the total number of bytes written
+    virtual int WriteBytes(unsigned char* buf, int count) = 0;
+};
+
+struct IRomFile : public IBaseInterface
+{
+    virtual bool GetRomFileStream(IReadStream** stream) = 0;
+    virtual bool GetSaveGameStream(IWriteStream** stream) = 0;
+    virtual bool GetLoadGameStream(IReadStream** stream) = 0;
+};
+
 struct INes : public IBaseInterface
 {
     virtual void DoFrame(unsigned char screen[]) = 0;

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -579,6 +579,7 @@ bool TxRom::Scanline()
 }
 
 // AxRom, Mapper #7
+
 AxRom::AxRom(Rom* rom)
     : NRom(rom)
     , _prgReg(0)

--- a/src/mapper.h
+++ b/src/mapper.h
@@ -6,7 +6,7 @@ class NRom : public IMapper, public NesObject
 {
 public:
     NRom(Rom* rom);
-    ~NRom();
+    virtual ~NRom();
     
 public:
     DELEGATE_NESOBJECT_REFCOUNTING();

--- a/src/nes.cpp
+++ b/src/nes.cpp
@@ -33,23 +33,23 @@ Nes::~Nes()
 
 bool Nes::Create(const char* romPath, IAudioProvider* audioProvider, Nes** nes)
 {
-    NPtr<Rom> rom(new Rom());
-    if (!rom->Load(romPath))
-        return false;
-
-    return Nes::Create(rom, audioProvider, nes);
+    NPtr<StdStreamRomFile> rom(new StdStreamRomFile(romPath));
+    return Nes::Create(static_cast<IRomFile*>(rom), audioProvider, nes);
 }
 
-bool Nes::Create(Rom* rom, IAudioProvider* audioProvider, Nes** nes)
+bool Nes::Create(IRomFile* romFile, IAudioProvider* audioProvider, Nes** nes)
 {
-    NPtr<IMapper> mapper;
-    if (!IMapper::CreateMapper(rom, &mapper))
+    NPtr<Rom> rom;
+    if (Rom::Create(romFile, &rom))
     {
-        return nullptr;
+        NPtr<IMapper> mapper;
+        if (IMapper::CreateMapper(rom, &mapper))
+        {
+            *nes = new Nes(rom, mapper, audioProvider);
+            return true;
+        }
     }
-
-    *nes = new Nes(rom, mapper, audioProvider);
-    return true;
+    return false;
 }
 
 void Nes::DoFrame(u8 screen[])
@@ -85,32 +85,32 @@ IStandardController* Nes::GetStandardController(unsigned int port)
 
 void Nes::SaveState()
 {
-    std::ofstream ofs(GetSavePath()->c_str(), std::fstream::binary | std::fstream::trunc);
-    _cpu->SaveState(ofs);
-    ofs.close();
+    //std::ofstream ofs(GetSavePath()->c_str(), std::fstream::binary | std::fstream::trunc);
+    //_cpu->SaveState(ofs);
+    //ofs.close();
 
-    printf("State Saved!\n");
+    //printf("State Saved!\n");
 }
 
 void Nes::LoadState()
 {
-    auto savePath = GetSavePath();
+    //auto savePath = GetSavePath();
 
-    if (!fs::exists(*savePath))
-    {
-        printf("No save state for this ROM.\n");
-        return;
-    }
+    //if (!fs::exists(*savePath))
+    //{
+    //    printf("No save state for this ROM.\n");
+    //    return;
+    //}
 
-    std::ifstream ifs(GetSavePath()->c_str(), std::fstream::binary);
-    _cpu->LoadState(ifs);
-    ifs.close();
+    //std::ifstream ifs(GetSavePath()->c_str(), std::fstream::binary);
+    //_cpu->LoadState(ifs);
+    //ifs.close();
 
-    printf("State Loaded!\n");
+    //printf("State Loaded!\n");
 }
 
-std::unique_ptr<fs::path> Nes::GetSavePath()
-{
-    fs::path savePath(_rom->Path());
-    return std::make_unique<fs::path>(savePath.replace_extension("ns"));
-}
+//std::unique_ptr<fs::path> Nes::GetSavePath()
+//{
+//    fs::path savePath(_rom->Path());
+//    return std::make_unique<fs::path>(savePath.replace_extension("ns"));
+//}

--- a/src/nes.h
+++ b/src/nes.h
@@ -20,7 +20,7 @@ public:
     DELEGATE_NESOBJECT_REFCOUNTING();
 
     static bool Create(const char* romPath, IAudioProvider* audioProvider, Nes** nes);
-    static bool Create(Rom* rom, IAudioProvider* audioProvider, Nes** nes);
+    static bool Create(IRomFile* rom, IAudioProvider* audioProvider, Nes** nes);
 
     // DoFrame runs all nes components until the ppu hits VBlank
     // This means that one call to DoFrame will render scanlines 241 - 261 then 0 - 240
@@ -38,7 +38,7 @@ public:
     void LoadState();
 
 private:
-    std::unique_ptr<fs::path> GetSavePath();
+    //std::unique_ptr<fs::path> GetSavePath();
 
 private:
     NPtr<Rom> _rom;

--- a/src/rom.h
+++ b/src/rom.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../include/nes_api.h"
 #include "mem.h"
 
 #include <vector>
@@ -76,24 +77,25 @@ struct INesHeader
 
 class Rom : public ISaveState, public NesObject
 {
+private:
+    Rom(IRomFile* romFile);
+
 public:
-    Rom();
-    virtual ~Rom();
+    static bool Create(IRomFile* romFile, Rom** rom);
+    ~Rom();
 
 public:
     DELEGATE_NESOBJECT_REFCOUNTING();
 
-    bool Load(std::string romPath);
-    const fs::path& Path();
-
 public:
-    void SaveState(std::ofstream& ofs);
-    void LoadState(std::ifstream& ifs);
+    virtual void SaveState(std::ofstream& ofs);
+    virtual void LoadState(std::ifstream& ifs);
 
 private:
+    bool Load();
+
     void SaveGame();
     void LoadGame();
-    std::unique_ptr<fs::path> GetSaveGamePath();
 
 public:
     INesHeader Header;
@@ -102,5 +104,114 @@ public:
     std::vector<u8> ChrRom;
 
 private:
-    fs::path _path;
+    NPtr<IRomFile> _romFile;
+};
+
+// TODO: These std stream implementations will be used by save state as well, so move them somewhere more accessible
+class StdReadStream : public IReadStream, public NesObject
+{
+private:
+    StdReadStream(const char* path)
+        : _stream(path, std::ios::binary)
+    {
+    }
+
+public:
+    static bool Create(const char* path, IReadStream** stream)
+    {
+        NPtr<StdReadStream> newStream(new StdReadStream(path));
+        if (newStream->_stream.is_open())
+        {
+            *stream = newStream.Detach();
+            return true;
+        }
+        else
+        {
+            *stream = nullptr;
+            return false;
+        }
+    }
+
+public:
+    DELEGATE_NESOBJECT_REFCOUNTING();
+
+public:
+    int ReadBytes(u8* buf, int count)
+    {
+        _stream.read((char*)buf, count);
+        return _stream.gcount();
+    }
+
+private:
+    std::ifstream _stream;
+};
+
+class StdWriteStream : public IWriteStream, public NesObject
+{
+private:
+    StdWriteStream(const char* path)
+        : _stream(path, std::ios::binary | std::ios::trunc) // TODO: Don't default to trunc?
+    {
+    }
+
+public:
+    static bool Create(const char* path, IWriteStream** stream)
+    {
+        NPtr<StdWriteStream> newStream(new StdWriteStream(path));
+        if (newStream->_stream.is_open())
+        {
+            *stream = newStream.Detach();
+            return true;
+        }
+        else
+        {
+            *stream = nullptr;
+            return false;
+        }
+    }
+
+public:
+    DELEGATE_NESOBJECT_REFCOUNTING();
+
+public:
+    int WriteBytes(u8* buf, int count)
+    {
+        _stream.write((char*)buf, count);
+        return 0; // TODO: fix?
+    }
+
+private:
+    std::ofstream _stream;
+};
+
+class StdStreamRomFile : public IRomFile, public NesObject
+{
+public:
+    StdStreamRomFile(const char* romPath)
+        : _romPath(romPath)
+    {
+    }
+
+public:
+    DELEGATE_NESOBJECT_REFCOUNTING();
+
+public:
+    bool GetRomFileStream(IReadStream** stream)
+    {
+        return StdReadStream::Create(_romPath, stream);
+    }
+
+    // TOOD: Path transfomration for these
+    bool GetSaveGameStream(IWriteStream** stream)
+    {
+        return false;
+    }
+
+    bool GetLoadGameStream(IReadStream** stream)
+    {
+        return false;
+    }
+
+private:
+    const char* _romPath;
 };


### PR DESCRIPTION
UWP's cannot use the std C++ file io stream classes the way that we are
using them today. I can see this being an issue across app platforms. This
is a first attempt at fixing this: The abstract RomBase class. It cannot
be instantiated directly and it must be derived per platform. This also
includes the StdStreamRom as an implementation using std streams like we
were previously.

TODO: We might want to do this by passing in an IRomFileOperations
interface instead.