### PR TITLE
Remove unused parameters/fields

### DIFF
--- a/src/apu.cpp
+++ b/src/apu.cpp
@@ -298,7 +298,7 @@ Apu::~Apu()
     _noiseState = nullptr;
 }
 
-void Apu::StartAudio(MemoryMap* cpuMemMap, int preferredSampleRate)
+void Apu::StartAudio(MemoryMap* cpuMemMap)
 {
     int pulseMinFreq = WavelengthToFrequency(false, 0x07FF);
     int pulseMaxFreq = WavelengthToFrequency(false, 0x0008);
@@ -306,7 +306,6 @@ void Apu::StartAudio(MemoryMap* cpuMemMap, int preferredSampleRate)
     int triangleMaxFreq = WavelengthToFrequency(true, 0x0010);
 
     _audioEngine->StartAudio(
-        preferredSampleRate,
         _isPal ? CPU_FREQ_PAL : CPU_FREQ_NTSC,
         pulseMinFreq,
         pulseMaxFreq,

--- a/src/apu.h
+++ b/src/apu.h
@@ -30,7 +30,7 @@ public:
     DELEGATE_NESOBJECT_REFCOUNTING();
 
     // Audio control
-    void StartAudio(MemoryMap* cpuMemMap, int preferredSampleRate);
+    void StartAudio(MemoryMap* cpuMemMap);
     void StopAudio();
     void PauseAudio();
     void UnpauseAudio();

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -54,7 +54,6 @@ AudioEngine::~AudioEngine()
 }
 
 void AudioEngine::StartAudio(
-    int preferredSampleRate,
     int cpuFreq,
     int pulseMinFreq,
     int pulseMaxFreq,

--- a/src/audio.h
+++ b/src/audio.h
@@ -76,7 +76,6 @@ public:
     DELEGATE_NESOBJECT_REFCOUNTING();
 
     void StartAudio(
-        int preferredSampleRate,
         int cpuFreq,
         int pulseMinFreq,
         int pulseMaxFreq,

--- a/src/nes.cpp
+++ b/src/nes.cpp
@@ -14,18 +14,17 @@
 
 Nes::Nes(Rom* rom, IMapper* mapper, IAudioProvider* audioProvider)
     : _rom(rom)
-    , _mapper(mapper)
 {
     _debugger = new DebugService();
-    _ppu = new Ppu(_mapper);
+    _ppu = new Ppu(mapper);
     _apu = new Apu(false, audioProvider);
     _input = new Input();
-    _mem = new MemoryMap(_ppu, _apu, _input, _mapper);
+    _mem = new MemoryMap(_ppu, _apu, _input, mapper);
     _cpu = new Cpu(_mem, _debugger);
 
     // TODO: Move these to an init method
     _cpu->Reset();
-    _apu->StartAudio(_mem, 44100); 
+    _apu->StartAudio(_mem); 
 }
 
 Nes::~Nes()

--- a/src/nes.h
+++ b/src/nes.h
@@ -44,7 +44,6 @@ private:
 
 private:
     NPtr<Rom> _rom;
-    NPtr<IMapper> _mapper;
     NPtr<Apu> _apu;
     NPtr<Ppu> _ppu;
     NPtr<Input> _input;


### PR DESCRIPTION
Removed unused APU parameter.  Also remove `NPtr<IMapper>` field from nes.  This was not used and will be difficult to marshal correctly when debugging.