### PR TITLE
More audio fixes

### DIFF
--- a/neSDL/neSDL.cpp
+++ b/neSDL/neSDL.cpp
@@ -11,7 +11,7 @@ int main(int argc, char* argv[])
         return -1;
     }
 
-    NPtr<SdlAudioProvider> audioProvider(new SdlAudioProvider(44100));
+    NPtr<SdlAudioProvider> audioProvider(new SdlAudioProvider(32000));
     NPtr<INes> nes;
     if (!Nes_Create(argv[1], audioProvider, &nes))
     {

--- a/src/apu.cpp
+++ b/src/apu.cpp
@@ -27,8 +27,7 @@ const int LengthCounterSetValues[32] =
 
 const int NoisePeriodValues[16] =
 {
-    0x01AC, 0x017C, 0x0154, 0x0140, 0x011E, 0x00FE, 0x00E2, 0x00D6,
-    0x00BE, 0x00A0, 0x008E, 0x0080, 0x006A, 0x0054, 0x0048, 0x0036
+    4, 8, 16, 32, 64, 96, 128, 160, 202, 254, 380, 508, 762, 1016, 2034, 4068
 };
 
 const int DmcRateNTSC[16] =

--- a/src/audio.h
+++ b/src/audio.h
@@ -4,6 +4,7 @@
 #include "interfaces.h"
 
 struct IAudioProvider;
+class FilterChain;
 
 enum WavetableIndex
 {
@@ -105,7 +106,6 @@ private:
     i32 SampleNoise();
 
     void StepNoiseRegister();
-    int CycleCountToSampleCount(double cycleCount);
     static void BoundFrequency(u32& frequency, u32 minFreq, u32 maxFreq);
 
 private:
@@ -125,7 +125,7 @@ private:
     u32 _triangleMaxFreq;
     u32 _triangleFreqStep;
     u32 _phaseDivider;
-    double _cyclesPerSample;
+    int _cyclesPerSample;
 
     // Wavetables
     u8* _wavetableMemory;
@@ -136,20 +136,21 @@ private:
     std::atomic<u32> _pendingFrameResetCount;
     AudioEvent _nextEvent;
     int _samplesRemaining;
+    int _cycleCounter;
     bool _eventPending;
-    double _cycleCounter;
 
     // Channels (except for initialization, these should only be read/modified on the callback thread)
     WavetableChannel _pulseChannel1;
     WavetableChannel _pulseChannel2;
     WavetableChannel _triangleChannel;
+    std::shared_ptr<FilterChain> _outputFilter;
     i32 _dmcAmplitude;
     u16 _noiseShiftRegister;
     u32 _noiseVolume;
     bool _noiseMode1;
     bool _noiseOn;
-    double _noisePeriodSamples;
-    double _noiseCounter;
+    int _noisePeriodSamples;
+    int _noiseCounter;
 
     friend void AudioGenerateCallback(void *userdata, u8 *stream, int len);
 };

--- a/windows/winrt/NesRuntimeComponent.cpp
+++ b/windows/winrt/NesRuntimeComponent.cpp
@@ -102,7 +102,7 @@ namespace NesRuntimeComponent
     {
         return create_async([=]() {
             NPtr<StorageFileRom> rom(new StorageFileRom(romFile));
-            NPtr<XA2AudioProvider> audioProvider(new XA2AudioProvider(44100));
+            NPtr<XA2AudioProvider> audioProvider(new XA2AudioProvider(32000));
             NPtr<::Nes> nes;
             ::Nes::Create(static_cast<IRomFile*>(rom), static_cast<IAudioProvider*>(audioProvider), &nes);
             return ref new Nes(nes);


### PR DESCRIPTION
More audio improvements:
1.  Noise period values were completely bogus - now using correct values.
2.  Noise period to samples calculation was incorrect.
3.  Made cycle counter an integer and changed sample rate to 32000.  This fixes some artifacts in the noise and DMC channel.  In the future, we'll need sample rate conversion to allow adjustable sample rate while keeping the channels in tune.
4.  Added DSP filter on the noise and DMC channels to more closely simulate the NES analog circuitry.
5.  Changed doubles to floats in the sampling code.  We don't need double precision and this will improve perf on some hardware.