### PR TITLE
Add key mapping for A

### DIFF
--- a/windows/uwp/MainPage.xaml.cs
+++ b/windows/uwp/MainPage.xaml.cs
@@ -118,6 +118,7 @@ namespace nesUWP
                 switch (args.VirtualKey)
                 {
                     case VirtualKey.S:
+                    case VirtualKey.O:
                         _controller0.A(state);
                         break;
                     case VirtualKey.A:


### PR DESCRIPTION
Add "O" key mapping for A button.  This makes the UWP app more friendly for Dvorak users.